### PR TITLE
Use ionCube loader 7.2 to work with PHP 7.2 (now used by default in vvv 2.2.1)

### DIFF
--- a/ioncube/provision.sh
+++ b/ioncube/provision.sh
@@ -5,16 +5,16 @@ echo "Setting up Ioncube"
 # Download Ioncube
 wget http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz &> /dev/null
 tar xvfz ioncube_loaders_lin_x86-64.tar.gz
-sudo cp ioncube/ioncube_loader_lin_7.0.so /usr/lib/php/20170718/
+sudo cp ioncube/ioncube_loader_lin_7.2.so /usr/lib/php/20170718/
 
 # Create the PHP config file
 cat > /etc/php/7.2/fpm/conf.d/00-ioncube.ini << EOF1
-zend_extension = "/usr/lib/php/20170718/ioncube_loader_lin_7.0.so"
+zend_extension = "/usr/lib/php/20170718/ioncube_loader_lin_7.2.so"
 EOF1
 
 # Restart 
-sudo systemctl restart nginx
-sudo systemctl restart php7.0-fpm.service
+sudo service nginx restart
+sudo service php7.2-fpm restart
 
 # Clean up
 sudo rm ioncube_loaders_lin_x86-64.tar.gz


### PR DESCRIPTION
I updated the provision script to use ionCube 7.2 loader as the latest version of vvv uses PHP 7.2 by default. I also changed the Nginx and PHP-FPM restart commands as for some reason the original systemctl restart was throwing an error.

It would be a nice feature to make the provision script detect which PHP version the vvv box uses and choose the ionCube loader accordingly. It would make it more future update proof. I didn't have time to look into it, but might do if I can find some.